### PR TITLE
Remove pull_request from workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,6 @@ name: CI
 
 # Run for PRs and the main branch
 on:
-  pull_request:
   pull_request_target:
   push:
     branches:


### PR DESCRIPTION
`pull_request` and `pull_request_target` are similar and they trigger two same runs.