### PR TITLE
Remove tldr usage in setup

### DIFF
--- a/source/computer/fedora-setup.rst
+++ b/source/computer/fedora-setup.rst
@@ -225,10 +225,6 @@ tldr
 
     $ sudo dnf install tldr
 
-用法::
-
-    $ tldr tar
-
 日常软件
 --------
 

--- a/source/computer/macos-setup.rst
+++ b/source/computer/macos-setup.rst
@@ -277,10 +277,6 @@ tldr
 
     $ brew install tldr
 
-用法::
-
-    $ tldr tar
-
 GNU 实用工具
 ^^^^^^^^^^^^
 

--- a/source/computer/ubuntu-setup.rst
+++ b/source/computer/ubuntu-setup.rst
@@ -233,10 +233,6 @@ tldr
 
     $ sudo apt install tldr
 
-用法::
-
-    $ tldr tar
-
 日常软件
 --------
 


### PR DESCRIPTION
We already have an example in `command`: https://seismo-learn.org/seismology101/computer/commands/
- [x] macOS
- [x] Fedora
- [x] Ubuntu