### PR TITLE
Add dependabot to automatically bump action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Set update schedule for GitHub Actions
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      # Check for updates to GitHub Actions every weekday
+      interval: "weekly"
+      day: "tuesday"
+    # Allow up to 5 open pull requests at a time
+    open-pull-requests-limit: 5


### PR DESCRIPTION
It runs every Tuesday so we don't need to update actions like #278.