### PR TITLE
M1 Mac需要对brew添加环境变量

### DIFF
--- a/source/computer/macos-setup.rst
+++ b/source/computer/macos-setup.rst
@@ -86,10 +86,12 @@ Homebrew
 
     $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
-M1 Mac 在安装完毕后，需要添加环境变量：
+.. note::
 
-    $ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
-    $ source ~/.zshrc
+   M1 Mac 在安装完毕后，需要添加环境变量::
+
+       $ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
+       $ source ~/.zshrc
 
 .. note::
 

--- a/source/computer/macos-setup.rst
+++ b/source/computer/macos-setup.rst
@@ -86,6 +86,11 @@ Homebrew
 
     $ /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
+M1 Mac 在安装完毕后，需要添加环境变量：
+
+    $ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
+    $ source ~/.zshrc
+
 .. note::
 
    GitHub 在国内访问不畅，以上安装命令可能由于网络问题而失败。

--- a/source/computer/macos-setup.rst
+++ b/source/computer/macos-setup.rst
@@ -88,7 +88,7 @@ Homebrew
 
 .. note::
 
-   M1 Mac 在安装完毕后，需要添加环境变量::
+   在最新的 Apple M1 芯片的 macOS 下安装 Homebrew 后，还需要设置环境变量::
 
        $ echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zshrc
        $ source ~/.zshrc


### PR DESCRIPTION
上次的测试结果显示，如果在环境变量文件zshrc里面注释掉brew的相关内容，brew和它安装的软件依然可以正常使用。所以后来我就保持注释的状态。

我后来重启了电脑

发现brew不能用了，然后在环境变量里恢复，重新source，就又能用了。