### PR TITLE
Update workflow comments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,8 +31,6 @@ jobs:
         run: make dirhtml
 
       - name: Deploy documentation
-        # peaceiris/actions-gh-pages@v3.7.3
-        # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
         uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -29,8 +29,6 @@ jobs:
         run: make dirhtml
 
       - name: Deploy for preview
-        # peaceiris/actions-gh-pages@v3.7.3
-        # Don't use tags: https://julienrenaux.fr/2019/12/20/github-actions-security-risk/
         uses: peaceiris/actions-gh-pages@068dc23d9710f1ba62e86896f84735d869951305
         with:
           # personal token can be generated at https://github.com/settings/tokens,


### PR DESCRIPTION
The two workflows were updated this morning, and we're using
peaceiris/actions-gh-pages@v3.8.0 now.

As it's automatically updated by dependabot now, the comments are
useless.