### PR TITLE
Ignore the sphinx.mo file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Documentation
 build
 _build
+sphinx.mo
 
 # VS Code
 .vscode


### PR DESCRIPTION
sphinx.mo is the Sphinx language file (in binary format) automatically generated
from the file `locales/zh_CN/LC_MESSAGES/sphinx.po`.

Running `make html` locally will generate this file. Thus it should be ignored
by git.
