### PR TITLE
ohmyzsh git plugin no longer clashes with gmt

### DIFF
--- a/source/best-practices/zsh.rst
+++ b/source/best-practices/zsh.rst
@@ -164,12 +164,6 @@ Oh My Zsh 自带了很多插件，位于 :file:`~/.oh-my-zsh/plugins`\ 目录下
 
             $ brew install autojump
 
-    .. note::
-
-        `git 插件 <https://github.com/ohmyzsh/ohmyzsh/tree/master/plugins/git>`__\
-        为 git 的众多常用命令提供了更简单的别名。其中，``git mergetool --no-prompt`` 的别名
-        是 ``gmt``，与地学软件 GMT 冲突，建议不启用该插件。
-
 除了 Oh My Zsh 自带的插件，还可以使用第三方插件，只需提前安装即可。这里推荐几个常用的。
 
 -   `zsh-autosuggestions 插件 <https://github.com/zsh-users/zsh-autosuggestions>`__\ ：


### PR DESCRIPTION
The clash has been fixed by https://github.com/ohmyzsh/ohmyzsh/issues/9154.
