### PR TITLE
Update Ubuntu ISO image to 20.04.3

### DIFF
--- a/source/computer/ubuntu-setup.rst
+++ b/source/computer/ubuntu-setup.rst
@@ -12,7 +12,7 @@ Ubuntu 配置指南
 
    本节内容适用于 **Ubuntu Desktop 20.04.3 LTS**，不一定适用于其他 Ubuntu 版本。
    建议用户总是选择 Ubuntu 最新的长期支持版（目前是 Ubuntu 20.04 LTS）或最新版本
-   （目前是 Ubuntu 21.04），也欢迎用户帮助我们更新本文以适配 Ubuntu 最新版本。
+   （目前是 Ubuntu 21.10），也欢迎用户帮助我们更新本文以适配 Ubuntu 最新版本。
 
 .. note::
 


### PR DESCRIPTION
With Ubuntu 20.04.3 released, the two links for the 20.04.2 ISO files are dead.

This PR updates the links and the Ubunutu version string.

Closes https://github.com/seismo-learn/website/issues/87