### PR TITLE
Migrate from sphinx-panels to sphinx-design

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 sphinx
 sphinx-cjkspace
 sphinx-copybutton
-sphinx-panels
+sphinx-design
 sphinx_rtd_theme

--- a/source/best-practices/backup-Linux.rst
+++ b/source/best-practices/backup-Linux.rst
@@ -53,21 +53,27 @@ DejaDup
 
 安装 DejaDup：
 
-.. tabbed:: Fedora
 
-   ::
+.. tab-set::
 
-       $ sudo dnf install deja-dup
+    .. tab-item:: Fedora
+        :sync: fedora
 
-.. tabbed:: CentOS
+        ::
 
-   ::
+            $ sudo dnf install deja-dup
 
-       $ sudo yum install deja-dup
+    .. tab-item:: CentOS
+        :sync: centos
 
-.. tabbed:: Ubuntu/Debian
+        ::
 
-   ::
+            $ sudo yum install deja-dup
 
-       $ sudo apt update
-       $ sudo apt install deja-dup
+    .. tab-item:: Ubuntu/Debian
+       :sync: ubuntu-debian
+
+       ::
+
+           $ sudo apt update
+           $ sudo apt install deja-dup

--- a/source/best-practices/backup.rst
+++ b/source/best-practices/backup.rst
@@ -42,25 +42,25 @@ OneDrive、Google Drive、Dropbox、iCloud 等）。需要注意，若误删本�
 
 建议每隔一段时间（如每周）做一次备份。放假前、出差开会前，也建议备份一下。
 
-.. panels::
-    :container: container-lg pb-3
-    :column: col-lg-4 col-md-4 col-sm-4 col-xs-6 p-2
+.. grid:: 1 2 2 4
 
-    .. toctree::
-        :maxdepth: 2
+    .. grid-item-card::
 
-        backup-Linux
+        .. toctree::
+            :maxdepth: 2
 
-    ---
+            backup-Linux
 
-    .. toctree::
-        :maxdepth: 2
+    .. grid-item-card::
 
-        backup-macOS
+        .. toctree::
+            :maxdepth: 2
 
-    ---
+            backup-macOS
 
-    .. toctree::
-        :maxdepth: 2
+    .. grid-item-card::
 
-        backup-Windows
+        .. toctree::
+            :maxdepth: 2
+
+            backup-Windows

--- a/source/best-practices/zsh.rst
+++ b/source/best-practices/zsh.rst
@@ -26,23 +26,28 @@ Zsh 有如下特点：
 
 Linux 用户可以使用如下命令安装 Zsh：
 
-.. tabbed:: Fedora
+.. tab-set::
 
-    ::
+    .. tab-item:: Fedora
+        :sync: fedora
 
-        $ sudo dnf install zsh
+        ::
 
-.. tabbed:: CentOS
+            $ sudo dnf install zsh
 
-    ::
+    .. tab-item:: CentOS
+        :sync: centos
 
-        $ sudo yum install zsh
+        ::
 
-.. tabbed:: Ubuntu/Debian
+            $ sudo yum install zsh
 
-    ::
+    .. tab-item:: Ubuntu/Debian
+        :sync: ubuntu-debian
 
-        $ sudo apt install zsh
+        ::
+
+            $ sudo apt install zsh
 
 通过如下命令设置默认 Shell 为 Zsh::
 
@@ -52,23 +57,27 @@ Linux 用户可以使用如下命令安装 Zsh：
 用户的默认 Shell 就从 Bash 变成 Zsh 了。打开新的终端并键入
 ``echo $SHELL``，查看当前 Shell，会显示 :file:`/bin/zsh`。
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` chsh: command not found 错误
-    :container: + shadow
-    :title: bg-info text-white font-weight-bold
+.. dropdown:: chsh: command not found 错误
+    :color: info
+    :icon: info
 
     若出现 ``chsh: command not found`` 错误，则需要安装 util-linux-user:
 
-    .. tabbed:: Fedora
+    .. tab-set::
 
-        ::
+        .. tab-item:: Fedora
+            :sync: fedora
 
-            $ sudo dnf install util-linux-user
+            ::
 
-    .. tabbed:: CentOS
+                $ sudo dnf install util-linux-user
 
-        ::
+        .. tab-item:: CentOS
+            :sync: centos
 
-            $ sudo yum install util-linux-user
+            ::
+
+                $ sudo yum install util-linux-user
 
 Zsh 的配置文件为 :file:`~/.zshrc`。因而切换到 Zsh 后，
 所有的 Shell 配置都不用写到 :file:`~/.bashrc`，而要写到 :file:`~/.zshrc` 中。
@@ -156,31 +165,37 @@ Oh My Zsh 自带了很多插件，位于 :file:`~/.oh-my-zsh/plugins` 目录下�
 
     启用 autojump 插件前，需提前安装 `autojump <https://github.com/wting/autojump>`__:
 
-    .. tabbed:: Fedora
 
-        ::
+    .. tab-set::
 
-            $ sudo dnf install autojump-zsh
+        .. tab-item:: Fedora
+            :sync: fedora
 
-    .. tabbed:: CentOS
+            ::
 
-        ::
+                $ sudo dnf install autojump-zsh
 
-            $ sudo yum install autojump-zsh
+        .. tab-item:: CentOS
+            :sync: centos
 
-    .. tabbed:: Ubuntu/Debian
+            ::
 
-        ::
+                $ sudo yum install autojump-zsh
 
-            # 安装后，还要根据 /usr/share/doc/autojump/README.Debian 里的要求做进一步设置
-            $ sudo apt install autojump
+        .. tab-item:: Ubuntu/Debian
+            :sync: ubuntu-debian
 
+            ::
 
-    .. tabbed:: macOS
+                # 安装后，还要根据 /usr/share/doc/autojump/README.Debian 里的要求做进一步设置
+                $ sudo apt install autojump
 
-        ::
+        .. tab-item:: macOS
+            :sync: macos
 
-            $ brew install autojump
+            ::
+
+                $ brew install autojump
 
 除了 Oh My Zsh 自带的插件，还可以使用第三方插件，只需提前安装即可。这里推荐几个常用的。
 

--- a/source/computer/commands.rst
+++ b/source/computer/commands.rst
@@ -33,78 +33,52 @@ Linux/macOS 下有成百上千个命令，每个命令都有众多选项。一�
 
 .. rubric:: 命令目录
 
-.. panels::
-    :container: container-lg pb-3
-    :column: col-lg-3 col-md-3 col-sm-4 col-xs-6 p-2
+.. grid:: 1 2 2 3
 
-    文件查看
-    ^^^^^^^^
+    .. grid-item-card:: 文件查看
 
-    - `cat`_
-    - `head`_
-    - `less`_
-    - `tail`_
+        - `cat`_
+        - `head`_
+        - `less`_
+        - `tail`_
 
-    ---
+    .. grid-item-card:: 文件处理
 
-    文件处理
-    ^^^^^^^^
+        - `diff`_
+        - `gawk`_
+        - `grep`_
+        - `sed`_
+        - `sort`_
+        - `uniq`_
+        - `wc`_
 
-    - `diff`_
-    - `gawk`_
-    - `grep`_
-    - `sed`_
-    - `sort`_
-    - `uniq`_
-    - `wc`_
+    .. grid-item-card:: 文件搜索
 
-    ---
+        - `find`_
+        - `locate`_
 
-    文件搜索
-    ^^^^^^^^
+    .. grid-item-card:: 文件传输
 
-    - `find`_
-    - `locate`_
+        - `rsync`_
+        - `scp`_
 
-    ---
+    .. grid-item-card:: 文件下载
 
-    文件传输
-    ^^^^^^^^
+        - `wget`_
 
-    - `rsync`_
-    - `scp`_
+    .. grid-item-card:: 压缩与解压
 
-    ---
+        - `tar`_
 
-    文件下载
-    ^^^^^^^^
+    .. grid-item-card:: 系统管理
 
-    - `wget`_
+        - `df`_
+        - `du`_
+        - `top`_
 
-    ---
+    .. grid-item-card:: 远程登录
 
-    压缩与解压
-    ^^^^^^^^^^
-
-    - `tar`_
-
-    ---
-
-    系统管理
-    ^^^^^^^^
-
-    - `df`_
-    - `du`_
-    - `top`_
-
-    ---
-
-    远程登录
-    ^^^^^^^^
-
-    - `ssh`_
-
-----
+        - `ssh`_
 
 cat
 ---

--- a/source/computer/environment-variable.rst
+++ b/source/computer/environment-variable.rst
@@ -42,9 +42,9 @@ Shell 环境由环境变量、Shell 变量、Shell 函数和别名等组成，�
     $ echo $PATH
     /usr/local/bin:/usr/local/sbin:/usr/bin:/usr/sbin:/bin:/sbin
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` 查看命令所在目录
-   :container: +shadow
-   :title: bg-info text-white font-weight-bold
+.. dropdown:: 查看命令所在目录
+   :color: info
+   :icon: info
 
    可以使用 ``which`` 或 ``whereis`` 命令查询命令所在目录::
 

--- a/source/computer/fedora-setup.rst
+++ b/source/computer/fedora-setup.rst
@@ -209,9 +209,9 @@ Intel 软件开发工具包
 
     $ echo "source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1" >> ~/.bashrc
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` 查看 Intel 软件仓库提供的软件列表
-    :container: + shadow
-    :title: bg-info text-white font-weight-bold
+.. dropdown:: 查看 Intel 软件仓库提供的软件列表
+    :color: info
+    :icon: info
 
     使用如下命令可以列出 Intel 软件仓库提供的所有软件包::
 

--- a/source/computer/macos-setup.rst
+++ b/source/computer/macos-setup.rst
@@ -258,9 +258,9 @@ Intel 软件开发工具包
 
     $ echo "source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1" >> ~/.zshrc
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` Intel 软件开发工具列表
-   :class-container: shadow
-   :class-title: bg-info text-white font-weight-bold
+.. dropdown:: Intel 软件开发工具列表
+   :color: info
+   :icon: info
 
    Intel oneAPI 提供了众多软件开发工具，用户可以根据需要到
    `Intel 官网 <https://software.intel.com/content/www/us/en/develop/articles/oneapi-standalone-components.html>`__

--- a/source/computer/macos-setup.rst
+++ b/source/computer/macos-setup.rst
@@ -150,9 +150,9 @@ Homebrew
 
     Homebrew 用户也可以访问网站 https://formulae.brew.sh/ 查看软件包。
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` Homebrew 相关名词解释
-   :container: + shadow
-   :title: bg-info text-white font-weight-bold
+.. dropdown:: Homebrew 相关名词解释
+   :color: info
+   :icon: info
 
    使用 Homebrew 时会碰到很多名词。这里做简单解释，
    更详细的解释请查看\ `官方文档 <https://docs.brew.sh/Formula-Cookbook#homebrew-terminology>`__。
@@ -200,9 +200,9 @@ C/C++
 Command Line Tools for Xcode 已经提供了 C/C++ 编译器和相关工具，因而无需单独安装
 C/C++ 编译器。
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` GCC 编译器
-   :container: + shadow
-   :title: bg-info text-white font-weight-bold
+.. dropdown:: GCC 编译器
+   :color: info
+   :icon: info
 
     Command Line Tools for Xcode 提供的 C/C++ 编译器本质上是
     `Apple Clang <https://opensource.apple.com/source/clang/clang-23/clang/tools/clang/docs/UsersManual.html>`__ 编译器，
@@ -259,8 +259,8 @@ Intel 软件开发工具包
     $ echo "source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1" >> ~/.zshrc
 
 .. dropdown:: :fa:`exclamation-circle,mr-1` Intel 软件开发工具列表
-   :container: + shadow
-   :title: bg-info text-white font-weight-bold
+   :class-container: shadow
+   :class-title: bg-info text-white font-weight-bold
 
    Intel oneAPI 提供了众多软件开发工具，用户可以根据需要到
    `Intel 官网 <https://software.intel.com/content/www/us/en/develop/articles/oneapi-standalone-components.html>`__

--- a/source/computer/setup.rst
+++ b/source/computer/setup.rst
@@ -3,32 +3,32 @@
 
 这一节介绍如何安装和配置一些常见的操作系统，以满足日常科研工作的需求。
 
-.. panels::
-    :container: container-lg pb-3
-    :column: col-lg-3 col-md-3 col-sm-4 col-xs-6 p-2
+.. grid:: 1 2 2 4
 
-    .. toctree::
-        :maxdepth: 2
+    .. grid-item-card::
 
-        fedora-setup
+        .. toctree::
+           :maxdepth: 2
 
-    ---
+           fedora-setup
 
-    .. toctree::
-        :maxdepth: 2
+    .. grid-item-card::
 
-        ubuntu-setup
+        .. toctree::
+           :maxdepth: 2
 
-    ---
+           ubuntu-setup
 
-    .. toctree::
-        :maxdepth: 2
+    .. grid-item-card::
 
-        macos-setup
+        .. toctree::
+           :maxdepth: 2
 
-    ---
+           macos-setup
 
-    .. toctree::
-        :maxdepth: 2
+    .. grid-item-card::
 
-        wsl-setup
+        .. toctree::
+           :maxdepth: 2
+
+           wsl-setup

--- a/source/computer/shell.rst
+++ b/source/computer/shell.rst
@@ -85,9 +85,9 @@ Shell 接收到用户输入的命令后，会以空格为分隔符将输入的�
 
    其他 Shell （如 Zsh, csh, ksh）的扩展语法可能稍微不同，以上示例可能不适用。
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` Shell 扩展和正则表达式的区别
-   :container: + shadow
-   :title: bg-info text-white font-weight-bold
+.. dropdown:: Shell 扩展和正则表达式的区别
+   :color: info
+   :icon: info
 
    读者可能以后会常接触到正则表达式（regular expression）。需要强调的是 Shell 扩展和
    正则表达式是不同的：

--- a/source/computer/ubuntu-setup.rst
+++ b/source/computer/ubuntu-setup.rst
@@ -216,9 +216,9 @@ Intel 软件开发工具包
 
     $ echo "source /opt/intel/oneapi/setvars.sh >/dev/null 2>&1" >> ~/.bashrc
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` 查看 Intel 软件仓库提供的软件列表
-    :container: + shadow
-    :title: bg-info text-white font-weight-bold
+.. dropdown:: 查看 Intel 软件仓库提供的软件列表
+    :color: info
+    :icon: info
 
     使用如下命令可以列出 Intel 软件仓库提供的所有软件包::
 

--- a/source/computer/wsl-setup.rst
+++ b/source/computer/wsl-setup.rst
@@ -39,9 +39,9 @@ WSL 有 WSL1 和 WSL2 两个发行版本，二者底层原理不同。大多数�
 
 官方目前没有弃用 WSL1 的计划，并且支持将任何一个已经安装的 Linux 发行版转换为 WSL1 或者 WSL2。
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` WSL2 与 VMware/VirtualBox 兼容性警告
-   :container: + shadow
-   :title: bg-warning text-red font-weight-bold
+.. dropdown:: WSL2 与 VMware/VirtualBox 兼容性警告
+   :color: info
+   :icon: info
 
    由于 Hyper-V 兼容性问题，开启 WSL2 功能后，老版本 VMware/VirtualBox 将无法正常使用。
    WSL1 和 VMware/VirtualBox 不存在兼容性问题，可同时运行。因此，已开启 WSL2 功能的用户

--- a/source/conf.py
+++ b/source/conf.py
@@ -46,7 +46,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_cjkspace.cjkspace",
     "sphinx_copybutton",
-    "sphinx_panels",
+    "sphinx_design",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/source/seismology/seismic-wave.rst
+++ b/source/seismology/seismic-wave.rst
@@ -162,9 +162,9 @@ Rayleigh 波在地表传播时，介质的运动既有与波传播方向相同�
 - 相速度（phase velocity）：波峰或波谷的传播速度，常用 :math:`c` 表示
 - 群速度（group velocity）：波包的传播速度，常用 :math:`U` 表示
 
-.. dropdown:: :fa:`exclamation-circle,mr-1` 相速度和群速度的示意图
-   :container: + shadow
-   :title: bg-info text-white font-weight-bold
+.. dropdown:: 相速度和群速度的示意图
+   :color: info
+   :icon: info
 
    如下图所示，波峰的传播速度是相速度；波包的传播速度是群速度。
 


### PR DESCRIPTION
As mentioned in #391, sphinx-panels will be replaced by sphinx-design in the future. sphinx-design is still in beta status, but it already works well, so this PR migrates from sphinx-panels to sphinx-design.

As you can see, these two sphinx extensions provide similar directives with different syntax. The syntax of sphinx-design is more readable thus easier to maintain. This PR just does the simple conversion from one syntax to another. 

We can set the directive options to further tweak the appearance of the tabs, dropdowns and grids. These will be done in future PRs to keep this PR small.

Closes #391.