### PR TITLE
Install java-11-openjdk instead of java-latest-openjdk

### DIFF
--- a/source/computer/fedora-setup.rst
+++ b/source/computer/fedora-setup.rst
@@ -3,7 +3,7 @@ Fedora 配置指南
 
 :本节贡献者: |田冬冬|\（作者）、
              |姚家园|\（审稿）
-:最近更新日期: 2021-10-02
+:最近更新日期: 2021-11-17
 :预计花费时间: 120 分钟
 
 ----
@@ -222,7 +222,7 @@ Java
 
 运行 Java 程序需要安装 Java 运行环境，即 OpenJDK::
 
-    $ sudo dnf install java-latest-openjdk
+    $ sudo dnf install java-11-openjdk
 
 Python
 ^^^^^^


### PR DESCRIPTION
Java 8, 11 and 17 are the LTS versions. Currently, most Linux distros
mainly use Java 11, but still provide Java 8.

java-latest-openjdk is the shortname for the latest Java version,
which may be unstable (e.g., Java 18). Thus, it's not a good idea
to install java-latest-openjdk, because some software may not work
with latest java versions (e.g., TauP).

Note that, the changes only affect Fedora, not Ubuntu. On Ubunut,
default-jdk always points to the latest stable Java version.

This PR addresses comment https://github.com/seismo-learn/seismology101/issues/367#issuecomment-970090503
