### PR TITLE
Rename the compress image workflow

### DIFF
--- a/.github/workflows/calibreapp-image-actions.yml
+++ b/.github/workflows/calibreapp-image-actions.yml
@@ -1,25 +1,23 @@
-# This workflow compresses images in PRs
 name: Compress Images
-
 on:
   pull_request:
+    # Run Image Actions when JPG, JPEG, PNG or WebP files are added or changed.
     paths:
       - '**.jpg'
       - '**.jpeg'
       - '**.png'
       - '**.webp'
-
 jobs:
-  compress:
+  build:
+    # Only run on Pull Requests within the same repository, and not from forks.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    name: Compress Images
+    name: calibreapp/image-actions
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+      - name: Checkout Repo
+        uses: actions/checkout@v2
 
       - name: Compress Images
-        uses: calibreapp/image-actions@1.1.0
+        uses: calibreapp/image-actions@main
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As you can see in https://github.com/seismo-learn/seismology101/pull/507#issuecomment-1113958687, the `compress-images` workflow requires some updates:

> Update required: Update image-actions configuration to the latest version before 1/1/21. See [README for instructions.](https://github.com/calibreapp/image-actions)