### PR TITLE
Bump jupyterbook to >=0.13

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,5 +6,4 @@ dependencies:
   - python=3.9
   - pip
   - obspy=1.3.0
-  - jupyter-book
-  - sphinx-design
+  - jupyter-book>=0.13

--- a/source/_config.yml
+++ b/source/_config.yml
@@ -45,7 +45,6 @@ latex:
 # Advanced sphinx settings
 sphinx:
   extra_extensions:
-    - sphinx_design
     - sphinx.ext.intersphinx
   config:
     intersphinx_mapping:


### PR DESCRIPTION
[jupyter-book v0.13](https://github.com/executablebooks/jupyter-book/releases/tag/v0.13) has been released. In this new version, `sphinx-design` is enabled by default, so we don't need to enable the extension ourselves.