### PR TITLE
Update bibliography and referencing style

### DIFF
--- a/source/_config.yml
+++ b/source/_config.yml
@@ -65,4 +65,5 @@ sphinx:
     copybutton_prompt_is_regexp: true
     copybutton_only_copy_prompt_lines: true
     copybutton_remove_prompts: true
-    bibtex_reference_style: author_year
+    bibtex_default_style: plain
+    bibtex_reference_style: super


### PR DESCRIPTION
See https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html?highlight=bibtex_reference_style#bibliography-style
> You can change the bibliography style, using the bibtex_default_style variable in your conf.py. If none is specified, the alpha style is used. 

See https://sphinxcontrib-bibtex.readthedocs.io/en/latest/usage.html?highlight=bibtex_reference_style#referencing-style:
> super: Use the labels generated by the bibliography style as superscripts. This works best with numeric bibliography styles such as plain. Similar to natbib’s super style and biblatex’s \supercite command.

The default bibliography style is `alpha`. Thus, for Oldham (1906), the generated label is `Old06`.
![](https://user-images.githubusercontent.com/50591376/177096489-8995e8e9-3925-4f2b-9779-a8b3d5e7486b.png)

![](https://user-images.githubusercontent.com/50591376/177097084-b81c33d8-fb3e-4a3b-b497-4ee2b16568c4.png)


---

This PR uses `plain` bibliography style, which is a numeric bibliography style.
![](https://user-images.githubusercontent.com/50591376/177096876-a0659e8c-b8a0-447f-8e62-d240f15abe6f.png)

![](https://user-images.githubusercontent.com/50591376/177097005-60747c39-4a79-4a88-8470-8ecdd0c69d31.png)

