### PR TITLE
Set notebook cache to auto so that notebooks are executed when changed

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Disable notebook cache for scheduled jobs
         if: github.event_name == 'schedule'
         run: |
-          sed -i"" 's/execute_notebooks: cache/execute_notebooks: force/' source/_config.yml
+          sed -i"" 's/execute_notebooks: auto/execute_notebooks: force/' source/_config.yml
 
       - name: Build documentation
         run: make dirhtml

--- a/source/_config.yml
+++ b/source/_config.yml
@@ -8,7 +8,7 @@ copyright : "2020–2022"
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
 execute:
-  execute_notebooks: cache
+  execute_notebooks: auto
 
 # Parse and render settings
 parse:


### PR DESCRIPTION
`execute_notebooks: cache` doesn't work because it only uses the cached output. When we add some new codes, it will fail to show the output of the new codes.