### PR TITLE
Cache cartopy and matplotlib directories

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,8 +38,11 @@ jobs:
       - uses: actions/cache@v3
         id: cache
         with:
-          path: _build/jupyter_execute/
-          key: notebooks
+          path: |
+            _build/jupyter_execute/
+            ~/.local/share/cartopy/
+            ~/.matplotlib/
+          key: caches
 
       - name: Disable notebook cache for scheduled jobs
         if: github.event_name == 'schedule'

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -31,8 +31,11 @@ jobs:
       - uses: actions/cache@v3
         id: cache
         with:
-          path: _build/jupyter_execute/
-          key: notebooks
+          path: |
+            _build/jupyter_execute/
+            ~/.local/share/cartopy/
+            ~/.matplotlib/
+          key: caches
 
       - name: Build documentation
         run: make dirhtml


### PR DESCRIPTION
When running `matplotlib` for the first time, it will give the following warning:
```
Matplotlib is building the font cache using fc-list. This may take a moment.
``` 
When plotting maps using cartopy, it will download coastline data and save to the cache directory.

Both show the warnings in the Jupyter Notebook output, so it may confuse readers.

In this PR, we cache matplotlib and cartopy's cache directories, so that building the notebooks, we won't see these warnings.