### PR TITLE
Bump to ObsPy 1.4.0

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -9,4 +9,4 @@ dependencies:
   - jupyter-book>=0.13
   - matplotlib
   - numpy
-  - obspy=1.3.1
+  - obspy=1.4.0


### PR DESCRIPTION
Bump to ObsPy 1.4.0, which also fixed https://github.com/seismo-learn/seismology101/issues/604.