### PR TITLE
Pin jupyter-book to v0.13

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.10
   - pip
   - cartopy
-  - jupyter-book>=0.13
+  - jupyter-book=0.14
   - matplotlib
   - numpy
   - obspy=1.4.0

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - python=3.10
   - pip
   - cartopy
-  - jupyter-book=0.14
+  - jupyter-book=0.13
   - matplotlib
   - numpy
   - obspy=1.4.0


### PR DESCRIPTION
jupyter-book v0.14 and v0.15 has been released, but

- v0.14 is not available on conda-forge so we can't use it.
- v0.15 is buggy with page width (see https://seismo-learn.org/sitepreview/seismo-learn/seismology101/seisman-patch-1/programming/languages/ and https://seismo-learn.org/sitepreview/seismo-learn/seismology101/seisman-patch-1/programming/bash/).

So pin jupyter-book to v0.13 now.