### PR TITLE
Replace conda-incubator/setup-miniconda with mamba-org/provision-with-micromamba

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,13 +27,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2.2.0
+      - name: Setup Micromamba
+        uses: mamba-org/provision-with-micromamba@v15
         with:
-          activate-environment: seismo-learn
           environment-file: environment.yml
-          miniforge-variant: Mambaforge
-          use-mamba: true
+          cache-downloads: true
+          cache-env: true
 
       - uses: actions/cache@v3
         id: cache


### PR DESCRIPTION
[provision-with-micromamba](https://github.com/mamba-org/provision-with-micromamba) uses micromamba, which is much faster than mamba.