### PR TITLE
Use the org-wide discussions

### DIFF
--- a/source/_toc.yml
+++ b/source/_toc.yml
@@ -83,5 +83,5 @@ parts:
       title: 地震“学”主站
     - url: https://seismo-learn.org/contributing/
       title: 贡献指南
-    - url: https://github.com/seismo-learn/seismology101/discussions
+    - url: https://github.com/orgs/seismo-learn/discussions
       title: 参与讨论


### PR DESCRIPTION
Instead of having discussions for each repository/documentation/project, I think it's easier to maintain using a single, org-wide discussions.

The org-wide discussions is enabled at https://github.com/organizations/seismo-learn/settings/discussions.

To enable the org-wide discussions, we have to choose a source repository. I think https://github.com/seismo-learn/maintenance is a good choice.
