### PR TITLE
Install java-17-openjdk on Fedora

### DIFF
--- a/source/computer/fedora-setup.md
+++ b/source/computer/fedora-setup.md
@@ -245,10 +245,10 @@ $ sudo dnf install gcc-gfortran
 
 ### Java
 
-运行 Java 程序需要安装 Java 运行环境，即 OpenJDK:
+运行 Java 程序需要安装 Java 运行环境，即 OpenJDK。
 
 ```
-$ sudo dnf install java-11-openjdk
+$ sudo dnf install java-17-openjdk
 ```
 
 ### git

--- a/source/computer/fedora-setup.md
+++ b/source/computer/fedora-setup.md
@@ -245,7 +245,7 @@ $ sudo dnf install gcc-gfortran
 
 ### Java
 
-运行 Java 程序需要安装 Java 运行环境，即 OpenJDK。
+运行 Java 程序需要安装 Java 运行环境，即 OpenJDK：
 
 ```
 $ sudo dnf install java-17-openjdk


### PR DESCRIPTION
I need to install `java-17-openjdk` to run TauP after upgrading to Fedora 38