### PR TITLE
Remove the outdated git tutorial

### DIFF
--- a/source/programming/git.md
+++ b/source/programming/git.md
@@ -5,7 +5,6 @@
 
 - [Pro Git](https://git-scm.com/book/zh/)（全面、系统）
 - [git 教程](https://www.liaoxuefeng.com/wiki/896043488029600)（较全面、系统）
-- [git 简易指南](https://www.bootcss.com/p/git-guide/)（简要）
 - [X 分钟速成 git](https://learnxinyminutes.com/docs/zh-cn/git-cn/)（简要）
 - [Pull Request 流程](https://seismo-learn.org/contributing/pull-request/)（简要）
 :::


### PR DESCRIPTION
The tutorial is very old (last updated in 2017), so should be removed.

Closes https://github.com/seismo-learn/maintenance/issues/41