### PR TITLE
WIP: Migrate to JupyterBook v2

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python=3.13
   - cartopy
-  - jupyter-book=1.0.4
+  - jupyter-book=2.0.2
   - matplotlib
   - numpy
   - obspy=1.4.2

--- a/myst.yml
+++ b/myst.yml
@@ -1,0 +1,15 @@
+# See docs at: https://mystmd.org/guide/frontmatter
+version: 1
+project:
+  id: f7e06311-b273-462c-bd92-fbea0552544b
+  # title:
+  # description:
+  # keywords: []
+  # authors: []
+  github: https://github.com/seismo-learn/seismology101
+  # To autogenerate a Table of Contents, run "jupyter book init --write-toc"
+site:
+  template: book-theme
+  # options:
+  #   favicon: favicon.ico
+  #   logo: site_logo.png


### PR DESCRIPTION
JupyterBook v2 is out.

This PR upgrades JupyterBook from v1 to v2 following https://jupyterbook.org/stable/resources/upgrade/#upgrade-tldr.

There are many warnings and must be fixed manually. So WIP.